### PR TITLE
Add TryFrom conversions for integer types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ libc = { version = "0.2", optional = true }
 
 [dev-dependencies]
 trybuild = "1"
+anyhow = "1.0"
 
 [workspace]
 members = [

--- a/derive/src/config.rs
+++ b/derive/src/config.rs
@@ -21,6 +21,7 @@ use syn::{parse::Parse, Error, Token, Visibility};
 pub struct Config {
     pub allow_alias: bool,
     pub repr_visibility: Visibility,
+    pub primitive_conversions: bool,
 }
 
 impl Parse for Config {
@@ -30,6 +31,7 @@ impl Parse for Config {
             repr_visibility: Visibility::Public(syn::VisPublic {
                 pub_token: Token![pub](Span::call_site()),
             }),
+            primitive_conversions: false,
         };
         let mut seen_names = HashSet::new();
         while !input.is_empty() {
@@ -59,6 +61,9 @@ impl Parse for Config {
                     if matches!(out.repr_visibility, syn::Visibility::Inherited) {
                         return Err(input.error("Expected visibility"));
                     }
+                }
+                "primitive_conversions" => {
+                    out.primitive_conversions = true;
                 }
                 unknown_name => {
                     return Err(Error::new(

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -211,6 +211,18 @@ fn open_enum_impl(
             )*
         }
         #alias_check
+
+        impl From<#inner_repr> for #ident {
+            fn from(val: #inner_repr) -> Self {
+                Self(val)
+            }
+        }
+
+        impl From<#ident> for #inner_repr {
+            fn from(val: #ident) -> Self {
+                val.0
+            }
+        }
     })
 }
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::Result;
+
 extern crate open_enum;
 use open_enum::*;
 
@@ -38,11 +40,12 @@ enum HasHash {
     Lemon,
 }
 
-#[open_enum]
+#[open_enum(primitive_conversions)]
+#[derive(Debug)]
 #[repr(i32)]
 enum ExplicitRepr {
-    Blah,
-    Boo,
+    Blah = -1,
+    Boo = 1,
 }
 
 #[repr(u64)]
@@ -86,7 +89,7 @@ fn values() {
     assert_eq!(AlreadyDerivesEq::Fizz.0, 0);
     assert_eq!(AlreadyDerivesEq::Buzz.0, 1);
 
-    assert_eq!(ExplicitRepr::Blah.0, 0);
+    assert_eq!(ExplicitRepr::Blah.0, -1);
     assert_eq!(ExplicitRepr::Boo.0, 1);
 
     assert_eq!(NegativeDiscriminant::What.0, -5);
@@ -116,6 +119,22 @@ fn to_integer() {
     assert_eq!(i8::from(Fruit::Banana), 2);
     assert_eq!(i8::from(Fruit::Blueberry), 5);
     assert_eq!(i8::from(Fruit::Raspberry), 6);
+}
+
+#[test]
+fn try_from_integer() -> Result<()> {
+    assert_eq!(ExplicitRepr::try_from(-1i8)?, ExplicitRepr::Blah);
+    assert_eq!(ExplicitRepr::try_from(1u64)?, ExplicitRepr::Boo);
+    assert!(ExplicitRepr::try_from(0xFFFF_FFFFu32).is_err());
+    Ok(())
+}
+
+#[test]
+fn try_to_integer() -> Result<()> {
+    assert_eq!(i8::try_from(ExplicitRepr::Blah)?, -1);
+    assert_eq!(u32::try_from(ExplicitRepr::Boo)?, 1);
+    assert!(u32::try_from(ExplicitRepr::Blah).is_err());
+    Ok(())
 }
 
 #[test]

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -16,6 +16,7 @@ extern crate open_enum;
 use open_enum::*;
 
 #[open_enum]
+#[derive(Debug)]
 enum Fruit {
     Apple,
     Pear,
@@ -96,6 +97,25 @@ fn values() {
     assert_eq!(Color::Crimson.0, 0);
     assert_eq!(Color::Blue.0, 1);
     assert_eq!(Color::Azure.0, 1);
+}
+
+#[test]
+fn from_integer() {
+    assert_eq!(Fruit::Apple, Fruit::from(0));
+    assert_eq!(Fruit::Pear, Fruit::from(1));
+    assert_eq!(Fruit::Banana, Fruit::from(2));
+    assert_eq!(Fruit::Blueberry, Fruit::from(5));
+    assert_eq!(Fruit::Raspberry, Fruit::from(6));
+}
+
+#[test]
+fn to_integer() {
+    // The `Fruit` enum autodetects the repr as `i8`.
+    assert_eq!(i8::from(Fruit::Apple), 0);
+    assert_eq!(i8::from(Fruit::Pear), 1);
+    assert_eq!(i8::from(Fruit::Banana), 2);
+    assert_eq!(i8::from(Fruit::Blueberry), 5);
+    assert_eq!(i8::from(Fruit::Raspberry), 6);
 }
 
 #[test]


### PR DESCRIPTION
When `primitive_conversions` is specified as an option to the
`open_enum` macro, `TryFrom` conversions will be implemented to
facilitate conversions between all integer types.

Signed-off-by: Chris Frantz <cfrantz@google.com>