### PR TITLE
Implement debug implementation that matches standard enums for non-aliased enums

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -81,8 +81,8 @@ fn check_no_alias<'a>(
 fn emit_debug_impl<'a>(
     ident: &Ident,
     variants: impl Iterator<Item = &'a Ident> + Clone,
-) -> syn::Result<TokenStream> {
-    Ok(quote!(impl ::core::fmt::Debug for #ident {
+) -> TokenStream {
+    quote!(impl ::core::fmt::Debug for #ident {
         fn fmt(&self, fmt: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
             #![allow(unreachable_patterns)]
             let s = match *self {
@@ -93,7 +93,7 @@ fn emit_debug_impl<'a>(
             };
             fmt.pad(s)
         }
-    }))
+    })
 }
 
 fn open_enum_impl(
@@ -153,8 +153,8 @@ fn open_enum_impl(
                     }
 
                     // If we allow aliasing, then don't bother with a custom
-                    // debug impl. There's no way to tell which alias we
-                    // should print.
+                    // debug impl. There's no way to tell which alias we should
+                    // print.
                     if derive.is_ident("Debug") && !allow_alias {
                         make_custom_debug_impl = true;
                         include_in_struct = false;
@@ -212,7 +212,7 @@ fn open_enum_impl(
     let syn::ItemEnum { ident, vis, .. } = enum_;
 
     let debug_impl = if make_custom_debug_impl {
-        emit_debug_impl(&ident, variants.iter().map(|(i, _, _, _)| *i))?
+        emit_debug_impl(&ident, variants.iter().map(|(i, _, _, _)| *i))
     } else {
         TokenStream::default()
     };

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -152,7 +152,7 @@ fn open_enum_impl(
                         our_derives.remove("Eq");
                     }
 
-                    // If we allow aliasing, then don't bother a custom
+                    // If we allow aliasing, then don't bother with a custom
                     // debug impl. There's no way to tell which alias we
                     // should print.
                     if derive.is_ident("Debug") && !allow_alias {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -88,7 +88,7 @@ fn emit_debug_impl<'a>(
             let s = match *self {
                 #( Self::#variants => stringify!(#variants), )*
                 _ => {
-                    return ::core::fmt::Debug::fmt(&self.0, fmt);
+                    return fmt.debug_tuple(stringify!(#ident)).field(&self.0).finish();
                 }
             };
             fmt.pad(s)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,44 @@
 //!
 //! ```
 //!
+//!
+//!
+//! # Custom debug implementation
+//! `open_enum` will generate a debug implementation that mirrors the standard `#[derive(Debug)]` for normal Rust enums
+//! by printing the name of the variant rather than the value contained, if the value is a named variant.
+//!
+//! However, if an enum has `#[open_enum(allow_alias)]` specified, the debug representation will be the numeric value only.
+//!
+//! For example, the given enum will have the following debug implementation emitted:
+//! ```no_run
+//! #[open_enum]
+//! #[derive(Debug)]
+//! enum Fruit {
+//!     Apple,
+//!     Pear,
+//!     Banana,
+//!     Blueberry = 5,
+//!     Raspberry,
+//! }
+//!
+//! impl ::core::fmt::Debug for Fruit {
+//! fn fmt(&self, fmt: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+//!         #![allow(unreachable_patterns)]
+//!         let s = match *self {
+//!             Self::Apple => stringify!(Apple),
+//!             Self::Pear => stringify!(Pear),
+//!             Self::Banana => stringify!(Banana),
+//!             Self::Blueberry => stringify!(Blueberry),
+//!             Self::Raspberry => stringify!(Raspberry),
+//!             _ => {
+//!                 return ::core::fmt::Debug::fmt(&self.0, fmt);
+//!             }
+//!         };
+//!         fmt.pad(s)
+//!     }
+//! }
+//! ```
+//!
 //! # Compared with `#[non_exhuastive]`
 //! The [`non_exhaustive`][non-exhaustive] attribute indicates that a type or variant
 //! may have more fields or variants added in the future. When applied to an `enum` (not its variants),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@
 //!             Self::Blueberry => stringify!(Blueberry),
 //!             Self::Raspberry => stringify!(Raspberry),
 //!             _ => {
-//!                 return ::core::fmt::Debug::fmt(&self.0, fmt);
+//!                 return fmt.debug_tuple(stringify!(Fruit)).field(&self.0).finish();
 //!             }
 //!         };
 //!         fmt.pad(s)

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -125,7 +125,14 @@ fn named_debug() {
         Fruit::Raspberry,
         Fruit(20),
     ];
-    let expected_output = ["Apple", "Banana", "Blueberry", "Pear", "Raspberry", "20"];
+    let expected_output = [
+        "Apple",
+        "Banana",
+        "Blueberry",
+        "Pear",
+        "Raspberry",
+        "Fruit(20)",
+    ];
 
     for (debug, expected) in fruits
         .iter()

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -16,6 +16,7 @@ extern crate open_enum;
 use open_enum::*;
 
 #[open_enum]
+#[derive(Debug)]
 enum Fruit {
     Apple,
     Pear,
@@ -111,6 +112,27 @@ fn match_() {
             Fruit(x) => format!("unknown fruit {x}"),
         };
         assert_eq!(fruit_str, expected);
+    }
+}
+
+#[test]
+fn named_debug() {
+    let fruits = [
+        Fruit::Apple,
+        Fruit::Banana,
+        Fruit::Blueberry,
+        Fruit::Pear,
+        Fruit::Raspberry,
+        Fruit(20),
+    ];
+    let expected_output = ["Apple", "Banana", "Blueberry", "Pear", "Raspberry", "20"];
+
+    for (debug, expected) in fruits
+        .iter()
+        .map(|f| format!("{f:?}"))
+        .zip(expected_output.iter())
+    {
+        assert_eq!(&debug.as_str(), expected)
     }
 }
 

--- a/tests/ui/lints.stderr
+++ b/tests/ui/lints.stderr
@@ -11,6 +11,14 @@ note: the lint level is defined here
    |             ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `open_enum` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error: missing documentation for an associated constant
+  --> tests/ui/lints.rs:26:5
+   |
+26 |     #[open_enum]
+   |     ^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `open_enum` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: missing documentation for a struct
   --> tests/ui/lints.rs:37:5
    |
@@ -22,6 +30,14 @@ note: the lint level is defined here
    |
 38 |     #[deny(missing_docs)]
    |            ^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `open_enum` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: missing documentation for an associated constant
+  --> tests/ui/lints.rs:37:5
+   |
+37 |     #[open_enum]
+   |     ^^^^^^^^^^^^
+   |
    = note: this error originates in the attribute macro `open_enum` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: missing documentation for a struct
@@ -37,6 +53,14 @@ note: the lint level is defined here
    |            ^^^^^^^^^^^^
    = note: this warning originates in the attribute macro `open_enum` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+warning: missing documentation for an associated constant
+  --> tests/ui/lints.rs:50:5
+   |
+50 |     #[open_enum]
+   |     ^^^^^^^^^^^^
+   |
+   = note: this warning originates in the attribute macro `open_enum` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: missing documentation for a struct
   --> tests/ui/lints.rs:61:5
    |
@@ -48,4 +72,12 @@ note: the lint level is defined here
    |
 62 |     #[forbid(missing_docs)]
    |              ^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `open_enum` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: missing documentation for an associated constant
+  --> tests/ui/lints.rs:61:5
+   |
+61 |     #[open_enum]
+   |     ^^^^^^^^^^^^
+   |
    = note: this error originates in the attribute macro `open_enum` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Emit a custom Debug implementation that prints the enumeration name if the struct has `#[derive(Debug)]` and is not aliased. This helps match standard rust enum Debug derive impls. 

Fixes #9 