### PR TITLE
Fix issue where #[cfg(...)] are not propogated to emitted debug implementation. 

### DIFF
--- a/derive/src/config.rs
+++ b/derive/src/config.rs
@@ -49,7 +49,7 @@ impl Parse for Config {
                 name_str @ "inner_vis" if !has_value => {
                     return Err(Error::new(
                         name.span(),
-                        &format!("Option `{name_str}` requires a value"),
+                        format!("Option `{name_str}` requires a value"),
                     ))
                 }
                 "inner_vis" => {
@@ -61,7 +61,7 @@ impl Parse for Config {
                 unknown_name => {
                     return Err(Error::new(
                         name.span(),
-                        &format!("Unknown option `{unknown_name}`"),
+                        format!("Unknown option `{unknown_name}`"),
                     ));
                 }
             }
@@ -71,7 +71,7 @@ impl Parse for Config {
             if !seen_names.insert(name_string) {
                 return Err(Error::new(
                     name.span(),
-                    &format!(
+                    format!(
                         "Option `{name}` listed more than once",
                         name = name.to_token_stream()
                     ),

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -85,9 +85,7 @@ fn emit_debug_impl<'a>(
 ) -> TokenStream {
     let attrs = attrs.map(|attrs| {
         // Only allow "#[cfg(...)]" attributes
-        let iter = attrs
-            .iter()
-            .filter(|attr| matches!(attr.path().to_token_stream().to_string().as_str(), "cfg",));
+        let iter = attrs.iter().filter(|attr| attr.path().is_ident("cfg"));
         quote!(#(#iter)*)
     });
     quote!(impl ::core::fmt::Debug for #ident {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -54,7 +54,7 @@ fn check_no_alias<'a>(
             if !values.insert(value) {
                 return Err(Error::new(
                     span,
-                    &format!("discriminant value `{value}` assigned more than once"),
+                    format!("discriminant value `{value}` assigned more than once"),
                 ));
             }
         } else {
@@ -120,17 +120,17 @@ fn path_matches_prelude_derive(
     }
     match &segments[..] {
         // `core::fmt::Debug` or `some_crate::module::Name`
-        &[maybe_core_or_std, maybe_a, maybe_b] => {
+        [maybe_core_or_std, maybe_a, maybe_b] => {
             (maybe_core_or_std.ident == "core" || maybe_core_or_std.ident == "std")
                 && maybe_a.ident == a
                 && maybe_b.ident == b
         }
         // `fmt::Debug` or `module::Name`
-        &[maybe_a, maybe_b] => {
+        [maybe_a, maybe_b] => {
             maybe_a.ident == a && maybe_b.ident == b && got_path.leading_colon.is_none()
         }
         // `Debug` or `Name``
-        &[maybe_b] => maybe_b.ident == b && got_path.leading_colon.is_none(),
+        [maybe_b] => maybe_b.ident == b && got_path.leading_colon.is_none(),
         _ => false,
     }
 }
@@ -196,12 +196,10 @@ fn open_enum_impl(
                             // This derive is always included, exclude it.
                             continue;
                         }
-                        if path_matches_prelude_derive(derive, DEBUG_PATH) {
-                            if !allow_alias {
-                                make_custom_debug_impl = true;
-                                // Don't include this derive since we're generating a special one.
-                                continue;
-                            }
+                        if path_matches_prelude_derive(derive, DEBUG_PATH) && !allow_alias {
+                            make_custom_debug_impl = true;
+                            // Don't include this derive since we're generating a special one.
+                            continue;
                         }
                         extra_derives.push(derive.to_token_stream());
                     }

--- a/tests/derives.rs
+++ b/tests/derives.rs
@@ -26,6 +26,17 @@ pub enum Color {
 }
 
 #[open_enum]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum ColorWithFeatures {
+    Red = 1,
+    Blue = 2,
+    /// Test doc
+    #[cfg(feature = "orange")]
+    Orange = 3,
+}
+
+#[open_enum]
 #[derive(
     core::fmt::Debug,
     std::clone::Clone,


### PR DESCRIPTION
When using feature gates with debug derives, the generated debug implementation does not correctly cfg gate enums that should be cfg gated, resulting in code that does not compile with the given feature. 

Fix this by making sure we emit `[#cfg(...)]` to the generated debug variants so that the code is correctly feature gated. 

Fixes #19 